### PR TITLE
Expose api with detailed args

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     url="https://github.com/eggplants/wbsv-cli",
     author="eggplants",
     packages=find_packages(),
-    python_requires=">=3.5",
+    python_requires=">=3.7",
     include_package_data=True,
     license="MIT",
     install_requires=open("requirements.txt").read().splitlines(),

--- a/test_wbsv.py
+++ b/test_wbsv.py
@@ -1,4 +1,39 @@
+from urllib.parse import urlparse
+
 from wbsv import crawler, main
+
+
+#UrlFilter unit tests
+from wbsv.url_filters import SchemaFilter, OwnDomainFilter
+
+
+def test_schema_filter_should_reject_invalid_schema():
+
+    schema_filter = SchemaFilter()
+    invalid_schema_url = urlparse("data://test.txt")
+
+    assert schema_filter.test_url(invalid_schema_url) is False
+
+
+def test_schema_filter_should_accept_valid_schema():
+    schema_filter = SchemaFilter()
+    valid_schema_url = urlparse("https://example.com")
+
+    assert schema_filter.test_url(valid_schema_url) is True
+
+
+def test_own_domain_filter_should_reject_url_with_invalid_domain():
+    own_domain_filter = OwnDomainFilter.from_string_urls(["https://example.com"])
+    invalid_domain_url = urlparse("https://www.iana.org")
+
+    assert own_domain_filter.test_url(invalid_domain_url) is False
+
+
+def test_own_domain_filter_should_accept_url_with_valid_domain():
+    own_domain_filter =  OwnDomainFilter.from_string_urls(["https://example.com"])
+    invalid_domain_url = urlparse("https://example.com")
+
+    assert own_domain_filter.test_url(invalid_domain_url) is True
 
 
 def test_api_without_parser():
@@ -9,6 +44,7 @@ def test_api_without_parser():
     if urls != t:
         raise AssertionError
 
+
 def test1():
     args = main.parse_args(args_list=["https://example.com", "-l", "1"])
     c = crawler.Crawler.from_parser_args(args)
@@ -16,3 +52,4 @@ def test1():
     t = set().union(*c.run_crawl())
     if urls != t:
         raise AssertionError
+

--- a/test_wbsv.py
+++ b/test_wbsv.py
@@ -2,7 +2,7 @@ from wbsv import crawler, main
 
 
 def test1():
-    args = main.parse_args(test=["https://example.com", "-l", "1"])
+    args = main.parse_args(args_list=["https://example.com", "-l", "1"])
     c = crawler.Crawler(args)
     urls = {"https://example.com", "https://www.iana.org/domains/example"}
     t = set().union(*c.run_crawl())

--- a/test_wbsv.py
+++ b/test_wbsv.py
@@ -3,7 +3,7 @@ from urllib.parse import urlparse
 from wbsv import crawler, main
 
 
-#UrlFilter unit tests
+# UrlFilter unit tests
 from wbsv.url_filters import SchemaFilter, OwnDomainFilter
 
 
@@ -30,14 +30,19 @@ def test_own_domain_filter_should_reject_url_with_invalid_domain():
 
 
 def test_own_domain_filter_should_accept_url_with_valid_domain():
-    own_domain_filter =  OwnDomainFilter.from_string_urls(["https://example.com"])
+    own_domain_filter = OwnDomainFilter.from_string_urls(["https://example.com"])
     invalid_domain_url = urlparse("https://example.com")
 
     assert own_domain_filter.test_url(invalid_domain_url) is True
 
 
 def test_api_without_parser():
-    args = {"urls": ["https://example.com"], "own": False, "only_target": False, "level": 1}
+    args = {
+        "urls": ["https://example.com"],
+        "own": False,
+        "only_target": False,
+        "level": 1,
+    }
     c = crawler.Crawler.from_args(**args)
     urls = {"https://example.com", "https://www.iana.org/domains/example"}
     t = set().union(*c.run_crawl())
@@ -52,4 +57,3 @@ def test1():
     t = set().union(*c.run_crawl())
     if urls != t:
         raise AssertionError
-

--- a/test_wbsv.py
+++ b/test_wbsv.py
@@ -1,9 +1,17 @@
 from wbsv import crawler, main
 
 
+def test_api_without_parser():
+    args = {"urls": ["https://example.com"], "own": False, "only_target": False, "level": 1}
+    c = crawler.Crawler.from_args(**args)
+    urls = {"https://example.com", "https://www.iana.org/domains/example"}
+    t = set().union(*c.run_crawl())
+    if urls != t:
+        raise AssertionError
+
 def test1():
     args = main.parse_args(args_list=["https://example.com", "-l", "1"])
-    c = crawler.Crawler(args)
+    c = crawler.Crawler.from_parser_args(args)
     urls = {"https://example.com", "https://www.iana.org/domains/example"}
     t = set().union(*c.run_crawl())
     if urls != t:

--- a/wbsv/archiver.py
+++ b/wbsv/archiver.py
@@ -1,5 +1,6 @@
 import sys
-from typing import Union, Tuple
+from argparse import Namespace
+from typing import Union, Tuple, Literal
 
 import waybackpy
 
@@ -11,7 +12,7 @@ class SavepagenowFailureError(Exception):
 class Archiver:
 
     @staticmethod
-    def from_parser_args(args):
+    def from_parser_args(args: Namespace) -> 'Archiver':
         return Archiver(args.retry)
 
     def __init__(self, retry: int):
@@ -19,7 +20,7 @@ class Archiver:
         self.retry: int = retry
         self.UA: str = "Mozilla/5.0 (Windows NT 5.1; rv:40.0) " "Gecko/20100101 Firefox/40.0"
 
-    def archive(self, url) -> Union[bool, Tuple[str, bool]]:
+    def archive(self, url: str) -> Union[Literal[False], Tuple[str, bool]]:
         """Archive link."""
         wp = waybackpy.Url(url, self.UA)
         for _ in range(self.retry + 1):
@@ -30,7 +31,7 @@ class Archiver:
         return False
 
     @staticmethod
-    def _try_savepagenow(wp) -> bool:
+    def _try_savepagenow(wp: waybackpy.Url) -> bool:
         """Error handler for saving with savepagenow."""
         try:
             wp.save()

--- a/wbsv/archiver.py
+++ b/wbsv/archiver.py
@@ -2,7 +2,7 @@ import sys
 from argparse import Namespace
 from typing import Union, Tuple, Literal
 
-import waybackpy
+import waybackpy  # type: ignore
 
 
 class SavepagenowFailureError(Exception):
@@ -10,15 +10,16 @@ class SavepagenowFailureError(Exception):
 
 
 class Archiver:
-
     @staticmethod
-    def from_parser_args(args: Namespace) -> 'Archiver':
+    def from_parser_args(args: Namespace) -> "Archiver":
         return Archiver(args.retry)
 
     def __init__(self, retry: int):
         """Init."""
         self.retry: int = retry
-        self.UA: str = "Mozilla/5.0 (Windows NT 5.1; rv:40.0) " "Gecko/20100101 Firefox/40.0"
+        self.UA: str = (
+            "Mozilla/5.0 (Windows NT 5.1; rv:40.0) " "Gecko/20100101 Firefox/40.0"
+        )
 
     def archive(self, url: str) -> Union[Literal[False], Tuple[str, bool]]:
         """Archive link."""

--- a/wbsv/archiver.py
+++ b/wbsv/archiver.py
@@ -1,4 +1,5 @@
 import sys
+from typing import Union, Tuple
 
 import waybackpy
 
@@ -10,21 +11,21 @@ class SavepagenowFailureError(Exception):
 class Archiver:
     def __init__(self, args):
         """Init."""
-        self.retry = args.retry
-        self.UA = "Mozilla/5.0 (Windows NT 5.1; rv:40.0) " "Gecko/20100101 Firefox/40.0"
+        self.retry: int = args.retry
+        self.UA: str = "Mozilla/5.0 (Windows NT 5.1; rv:40.0) " "Gecko/20100101 Firefox/40.0"
 
-    def archive(self, url):
+    def archive(self, url) -> Union[bool, Tuple[str, bool]]:
         """Archive link."""
         wp = waybackpy.Url(url, self.UA)
         for _ in range(self.retry + 1):
             if not self._try_savepagenow(wp):
                 continue
             else:
-                return (wp.archive_url, wp.cached_save)
+                return wp.archive_url, wp.cached_save
         return False
 
     @staticmethod
-    def _try_savepagenow(wp):
+    def _try_savepagenow(wp) -> bool:
         """Error handler for saving with savepagenow."""
         try:
             wp.save()

--- a/wbsv/archiver.py
+++ b/wbsv/archiver.py
@@ -9,9 +9,14 @@ class SavepagenowFailureError(Exception):
 
 
 class Archiver:
-    def __init__(self, args):
+
+    @staticmethod
+    def from_parser_args(args):
+        return Archiver(args.retry)
+
+    def __init__(self, retry: int):
         """Init."""
-        self.retry: int = args.retry
+        self.retry: int = retry
         self.UA: str = "Mozilla/5.0 (Windows NT 5.1; rv:40.0) " "Gecko/20100101 Firefox/40.0"
 
     def archive(self, url) -> Union[bool, Tuple[str, bool]]:

--- a/wbsv/crawler.py
+++ b/wbsv/crawler.py
@@ -4,6 +4,8 @@ from urllib.parse import urldefrag, urljoin, urlparse
 import requests
 from bs4 import BeautifulSoup as BS
 
+from wbsv.url_filters import SchemaFilter, CombinedFilter, OwnDomainFilter, UrlFilter
+
 
 class MissingURLSchemaWarning(UserWarning):
     pass
@@ -16,27 +18,29 @@ class Crawler:
 
     @staticmethod
     def from_args(urls: Iterable[str], own: bool, only_target: bool, level: int):
-        normalized_urls = Crawler._normalize_urls_static_init(urls)
-        target_domains = {urlparse(u).netloc for u in normalized_urls} if own else set()
+        schema_filter = SchemaFilter()
+        normalized_urls = Crawler._normalize_urls(urls, schema_filter)
+        domain_filters = [
+            schema_filter,
+            OwnDomainFilter.from_string_urls(set(normalized_urls))
+        ] if own else [schema_filter]
         return Crawler(
             urls=normalized_urls,
-            own=own,
-            target_domains=target_domains,
+            domain_filter=CombinedFilter(domain_filters),
             only_target=only_target,
             level=level
         )
 
-    def __init__(self, urls, own, target_domains, only_target, level):
+    def __init__(self, urls: List, domain_filter: UrlFilter, only_target: bool, level: int):
         """Init."""
         self.urls = urls
-        self.own = own
-        self.target_domains = target_domains
+        self.domain_filter = domain_filter
         self.only_target = only_target
         self.level = level
         self.queue: List = []
         self.UA: str = "Mozilla/5.0 (Windows NT 5.1; rv:40.0) " "Gecko/20100101 Firefox/40.0"
 
-    def run_crawl(self):
+    def run_crawl(self) -> List:
         """Execute crawler."""
         if self.only_target:
             return [set(self.urls)]
@@ -45,7 +49,7 @@ class Crawler:
 
         return self.queue
 
-    def _crawl(self, now_level):
+    def _crawl(self, now_level) -> None:
         """Helper for crawling."""
         collecting_links = set()
         collected_links = set().union(*self.queue)
@@ -58,33 +62,16 @@ class Crawler:
                 urljoin(url, _.get("href")) for _ in set(data.find_all("a"))
             ]
             collecting_links |= set(
-                Crawler._normalize_urls_static(extracted_urls, own=self.own, target_domains=self.target_domains)
+                Crawler._normalize_urls(extracted_urls, url_filter=self.domain_filter)
             )
         self.queue.append(collecting_links - collected_links)
 
     @staticmethod
-    def _normalize_urls_static(urls: Iterable[str], own: bool, target_domains: Iterable[str]):
-        """Normalize url."""
+    def _normalize_urls(urls: Iterable[str], url_filter: UrlFilter) -> List[str]:
+        """Normalize parsed_url."""
         valid_urls = []
         for url in urls:
             parsed_url = urlparse(url)
-            if own:
-                if parsed_url.netloc not in target_domains:
-                    continue
-            if Crawler._check_schema_is_valid(parsed_url):
+            if url_filter.test_url(parsed_url):
                 valid_urls.append(urldefrag(parsed_url.geturl()).url)
         return valid_urls
-
-    @staticmethod
-    def _normalize_urls_static_init(urls: Iterable[str]):
-        valid_urls = []
-        for url in urls:
-            parsed_url = urlparse(url)
-            if Crawler._check_schema_is_valid(parsed_url):
-                valid_urls.append(urldefrag(parsed_url.geturl()).url)
-        return valid_urls
-
-    @staticmethod
-    def _check_schema_is_valid(parsed_url):
-        """Judge if given url has a valid schema."""
-        return parsed_url.scheme in {"http", "https", "ftp", "file"}

--- a/wbsv/crawler.py
+++ b/wbsv/crawler.py
@@ -1,5 +1,5 @@
+from typing import List
 from urllib.parse import urldefrag, urljoin, urlparse
-from warnings import warn
 
 import requests
 from bs4 import BeautifulSoup as BS
@@ -17,8 +17,8 @@ class Crawler:
         self.target_domains = [urlparse(u).netloc for u in self.urls]
         self.only_target = args.only_target
         self.level = args.level
-        self.queue = []
-        self.UA = "Mozilla/5.0 (Windows NT 5.1; rv:40.0) " "Gecko/20100101 Firefox/40.0"
+        self.queue: List = []
+        self.UA: str = "Mozilla/5.0 (Windows NT 5.1; rv:40.0) " "Gecko/20100101 Firefox/40.0"
 
     def run_crawl(self):
         """Execute crawler."""
@@ -44,7 +44,7 @@ class Crawler:
             collecting_links |= set(self._normalize_url(extracted_url))
         self.queue.append(collecting_links - collected_links)
 
-    def _normalize_url(self, urls, skip=False):
+    def _normalize_url(self, urls, skip: bool = False):
         """Normalize url."""
         valid_urls = []
         for url in urls:

--- a/wbsv/crawler.py
+++ b/wbsv/crawler.py
@@ -1,5 +1,5 @@
 from argparse import Namespace
-from typing import List, Iterable, Set, AbstractSet, Union, Any
+from typing import List, Iterable, Set
 from urllib.parse import urldefrag, urljoin, urlparse
 
 import requests
@@ -53,7 +53,7 @@ class Crawler:
     def _crawl(self, now_level: int) -> None:
         """Helper for crawling."""
         collecting_links = set()
-        collected_links_empty_set : Set[str] = set() #required for mypy type checking
+        collected_links_empty_set: Set[str] = set()  # required for mypy type checking
         collected_links: Set[str] = collected_links_empty_set.union(*self.queue)
         if now_level == 0:
             self.queue.append(set(self.urls))

--- a/wbsv/crawler.py
+++ b/wbsv/crawler.py
@@ -3,7 +3,7 @@ from typing import List, Iterable, Set
 from urllib.parse import urldefrag, urljoin, urlparse
 
 import requests
-from bs4 import BeautifulSoup as BS
+from bs4 import BeautifulSoup as BS  # type: ignore
 
 from wbsv.url_filters import SchemaFilter, CombinedFilter, OwnDomainFilter, UrlFilter
 
@@ -14,32 +14,39 @@ class MissingURLSchemaWarning(UserWarning):
 
 class Crawler:
     @staticmethod
-    def from_parser_args(args: Namespace) -> 'Crawler':
+    def from_parser_args(args: Namespace) -> "Crawler":
         return Crawler.from_args(args.url, args.own, args.only_target, args.level)
 
     @staticmethod
-    def from_args(urls: Iterable[str], own: bool, only_target: bool, level: int) -> 'Crawler':
+    def from_args(
+        urls: Iterable[str], own: bool, only_target: bool, level: int
+    ) -> "Crawler":
         schema_filter = SchemaFilter()
         normalized_urls = Crawler._normalize_urls(urls, schema_filter)
-        domain_filters = [
-            schema_filter,
-            OwnDomainFilter.from_string_urls(set(normalized_urls))
-        ] if own else [schema_filter]
+        domain_filters = (
+            [schema_filter, OwnDomainFilter.from_string_urls(set(normalized_urls))]
+            if own
+            else [schema_filter]
+        )
         return Crawler(
             urls=normalized_urls,
             domain_filter=CombinedFilter(domain_filters),
             only_target=only_target,
-            level=level
+            level=level,
         )
 
-    def __init__(self, urls: List[str], domain_filter: UrlFilter, only_target: bool, level: int):
+    def __init__(
+        self, urls: List[str], domain_filter: UrlFilter, only_target: bool, level: int
+    ):
         """Init."""
         self.urls = urls
         self.domain_filter = domain_filter
         self.only_target = only_target
         self.level = level
         self.queue: List[Set[str]] = []
-        self.UA: str = "Mozilla/5.0 (Windows NT 5.1; rv:40.0) " "Gecko/20100101 Firefox/40.0"
+        self.UA: str = (
+            "Mozilla/5.0 (Windows NT 5.1; rv:40.0) " "Gecko/20100101 Firefox/40.0"
+        )
 
     def run_crawl(self) -> List[Set[str]]:
         """Execute crawler."""

--- a/wbsv/crawler.py
+++ b/wbsv/crawler.py
@@ -53,7 +53,8 @@ class Crawler:
     def _crawl(self, now_level: int) -> None:
         """Helper for crawling."""
         collecting_links = set()
-        collected_links: AbstractSet[Union[Any, None]] = set().union(*self.queue)
+        collected_links_empty_set : Set[str] = set() #required for mypy type checking
+        collected_links: Set[str] = collected_links_empty_set.union(*self.queue)
         if now_level == 0:
             self.queue.append(set(self.urls))
         for url in self.queue[-1]:

--- a/wbsv/crawler.py
+++ b/wbsv/crawler.py
@@ -1,4 +1,5 @@
-from typing import List, Iterable
+from argparse import Namespace
+from typing import List, Iterable, Set, AbstractSet, Union, Any
 from urllib.parse import urldefrag, urljoin, urlparse
 
 import requests
@@ -13,11 +14,11 @@ class MissingURLSchemaWarning(UserWarning):
 
 class Crawler:
     @staticmethod
-    def from_parser_args(args):
+    def from_parser_args(args: Namespace) -> 'Crawler':
         return Crawler.from_args(args.url, args.own, args.only_target, args.level)
 
     @staticmethod
-    def from_args(urls: Iterable[str], own: bool, only_target: bool, level: int):
+    def from_args(urls: Iterable[str], own: bool, only_target: bool, level: int) -> 'Crawler':
         schema_filter = SchemaFilter()
         normalized_urls = Crawler._normalize_urls(urls, schema_filter)
         domain_filters = [
@@ -31,16 +32,16 @@ class Crawler:
             level=level
         )
 
-    def __init__(self, urls: List, domain_filter: UrlFilter, only_target: bool, level: int):
+    def __init__(self, urls: List[str], domain_filter: UrlFilter, only_target: bool, level: int):
         """Init."""
         self.urls = urls
         self.domain_filter = domain_filter
         self.only_target = only_target
         self.level = level
-        self.queue: List = []
+        self.queue: List[Set[str]] = []
         self.UA: str = "Mozilla/5.0 (Windows NT 5.1; rv:40.0) " "Gecko/20100101 Firefox/40.0"
 
-    def run_crawl(self) -> List:
+    def run_crawl(self) -> List[Set[str]]:
         """Execute crawler."""
         if self.only_target:
             return [set(self.urls)]
@@ -49,10 +50,10 @@ class Crawler:
 
         return self.queue
 
-    def _crawl(self, now_level) -> None:
+    def _crawl(self, now_level: int) -> None:
         """Helper for crawling."""
         collecting_links = set()
-        collected_links = set().union(*self.queue)
+        collected_links: AbstractSet[Union[Any, None]] = set().union(*self.queue)
         if now_level == 0:
             self.queue.append(set(self.urls))
         for url in self.queue[-1]:

--- a/wbsv/main.py
+++ b/wbsv/main.py
@@ -3,7 +3,7 @@ import argparse
 import http.client as httplib
 import sys
 import textwrap
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Iterable, Set, Any
 
 from wbsv import __version__
 from wbsv.archiver import Archiver
@@ -14,7 +14,7 @@ class HttpConnectionNotFountError(Exception):
     pass
 
 
-def check_connectivity(url: str = "www.google.com", timeout: int = 3):
+def check_connectivity(url: str = "www.google.com", timeout: int = 3) -> bool:
     conn = httplib.HTTPConnection(url, timeout=timeout)
     try:
         conn.request("HEAD", "/")
@@ -25,19 +25,19 @@ def check_connectivity(url: str = "www.google.com", timeout: int = 3):
         return False
 
 
-def check_natural(v: str):
+def check_natural(v: str) -> int:
     if int(v) < 0:
         raise argparse.ArgumentTypeError("%s is an invalid natural number" % int(v))
     return int(v)
 
 
-def check_positive(v: str):
+def check_positive(v: str) -> int:
     if int(v) <= 0:
         raise argparse.ArgumentTypeError("%s is an invalid natural number" % int(v))
     return int(v)
 
 
-def parse_args(args_list: Optional[List[str]] = None):
+def parse_args(args_list: Optional[List[str]] = None) -> argparse.Namespace:
     """Parse arguments."""
     parser = argparse.ArgumentParser(
         prog="wbsv",
@@ -94,11 +94,11 @@ def parse_args(args_list: Optional[List[str]] = None):
         return parser.parse_args()
 
 
-def wbsv(urls, own, only_target, level, retry) -> None:
+def wbsv(urls: Iterable[str], own: bool, only_target: bool, level: int, retry: int) -> None:
     past, now, fail = 0, 0, 0
     print("[+]Target: {}".format(urls))
     c = Crawler.from_args(urls=urls, own=own, only_target=only_target, level=level)
-    retrieved_links = set().union(*c.run_crawl())
+    retrieved_links: Set[Any] = set().union(*c.run_crawl())
     len_links: int = len(retrieved_links)
     print("[+]{} URI(s) found.".format(len_links))
     a = Archiver(retry)
@@ -118,11 +118,11 @@ def wbsv(urls, own, only_target, level, retry) -> None:
     print("[+]ALL: {}, NOW: {}, PAST: {}, FAIL: {}".format(len_links, now, past, fail))
 
 
-def wbsv_from_parser_args(args):
+def wbsv_from_parser_args(args: argparse.Namespace) -> None:
     wbsv(args.url, args.own, args.only_target, args.level, args.retry)
 
 
-def cache_or_now(ind, len_links: int, archived_link: str, cached_flag: bool) -> Tuple[int, int]:
+def cache_or_now(ind : int, len_links: int, archived_link: str, cached_flag: bool) -> Tuple[int, int]:
     if cached_flag:
         print("[{:02d}/{}]: <PAST> {}".format(ind, len_links, archived_link))
         return 1, 0
@@ -131,7 +131,7 @@ def cache_or_now(ind, len_links: int, archived_link: str, cached_flag: bool) -> 
         return 0, 1
 
 
-def wbsv_repl(args):
+def wbsv_repl(args: argparse.Namespace) -> None:
     finish_words = {"end", "exit", "exit()", "break", "bye", ":q", "finish"}
     print("[[Input a target url (ex: https://google.com)]]")
     while True:
@@ -149,7 +149,7 @@ def wbsv_repl(args):
                 print(e, file=sys.stderr)
 
 
-def _main():
+def _main() -> None:
     if not check_connectivity():
         raise HttpConnectionNotFountError
     args = parse_args()
@@ -159,7 +159,7 @@ def _main():
         wbsv_from_parser_args(args)
 
 
-def main():
+def main() -> None:
     try:
         _main()
     except KeyboardInterrupt:

--- a/wbsv/main.py
+++ b/wbsv/main.py
@@ -3,6 +3,7 @@ import argparse
 import http.client as httplib
 import sys
 import textwrap
+from typing import List, Optional, Tuple
 
 from wbsv import __version__
 from wbsv.archiver import Archiver
@@ -13,7 +14,7 @@ class HttpConnectionNotFountError(Exception):
     pass
 
 
-def check_connectivity(url="www.google.com", timeout=3):
+def check_connectivity(url: str = "www.google.com", timeout: int = 3):
     conn = httplib.HTTPConnection(url, timeout=timeout)
     try:
         conn.request("HEAD", "/")
@@ -24,19 +25,19 @@ def check_connectivity(url="www.google.com", timeout=3):
         return False
 
 
-def check_natural(v):
+def check_natural(v: str):
     if int(v) < 0:
         raise argparse.ArgumentTypeError("%s is an invalid natural number" % int(v))
     return int(v)
 
 
-def check_positive(v):
+def check_positive(v: str):
     if int(v) <= 0:
         raise argparse.ArgumentTypeError("%s is an invalid natural number" % int(v))
     return int(v)
 
 
-def parse_args(test=None):
+def parse_args(args_list: Optional[List[str]] = None):
     """Parse arguments."""
     parser = argparse.ArgumentParser(
         prog="wbsv",
@@ -87,8 +88,8 @@ def parse_args(test=None):
     parser.add_argument(
         "-V", "--version", action="version", version="%(prog)s {}".format(__version__)
     )
-    if test:
-        return parser.parse_args(test)
+    if args_list:
+        return parser.parse_args(args_list)
     else:
         return parser.parse_args()
 
@@ -98,7 +99,7 @@ def usual(args):
     print("[+]Target: {}".format(args.url))
     c = Crawler(args)
     retrieved_links = set().union(*c.run_crawl())
-    len_links = len(retrieved_links)
+    len_links: int = len(retrieved_links)
     print("[+]{} URI(s) found.".format(len_links))
     a = Archiver(args)
     for ind, link in enumerate(retrieved_links, 1):
@@ -117,13 +118,13 @@ def usual(args):
     print("[+]ALL: {}, NOW: {}, PAST: {}, FAIL: {}".format(len_links, now, past, fail))
 
 
-def cache_or_now(ind, len_links, archived_link, cached_flag):
+def cache_or_now(ind, len_links: int, archived_link: str, cached_flag: bool) -> Tuple[int, int]:
     if cached_flag:
         print("[{:02d}/{}]: <PAST> {}".format(ind, len_links, archived_link))
-        return (1, 0)
+        return 1, 0
     else:
         print("[{:02d}/{}]: <NOW> {}".format(ind, len_links, archived_link))
-        return (0, 1)
+        return 0, 1
 
 
 def repl(args):

--- a/wbsv/main.py
+++ b/wbsv/main.py
@@ -3,7 +3,7 @@ import argparse
 import http.client as httplib
 import sys
 import textwrap
-from typing import List, Optional, Tuple, Iterable, Set, Any
+from typing import List, Optional, Tuple, Iterable, Set
 
 from wbsv import __version__
 from wbsv.archiver import Archiver
@@ -98,7 +98,7 @@ def wbsv(urls: Iterable[str], own: bool, only_target: bool, level: int, retry: i
     past, now, fail = 0, 0, 0
     print("[+]Target: {}".format(urls))
     c = Crawler.from_args(urls=urls, own=own, only_target=only_target, level=level)
-    retrieved_links_empty_set : Set[str] = set() #required for mypy type checking
+    retrieved_links_empty_set: Set[str] = set()  # required for mypy type checking
     retrieved_links: Set[str] = retrieved_links_empty_set.union(*c.run_crawl())
     len_links: int = len(retrieved_links)
     print("[+]{} URI(s) found.".format(len_links))
@@ -123,7 +123,7 @@ def wbsv_from_parser_args(args: argparse.Namespace) -> None:
     wbsv(args.url, args.own, args.only_target, args.level, args.retry)
 
 
-def cache_or_now(ind : int, len_links: int, archived_link: str, cached_flag: bool) -> Tuple[int, int]:
+def cache_or_now(ind: int, len_links: int, archived_link: str, cached_flag: bool) -> Tuple[int, int]:
     if cached_flag:
         print("[{:02d}/{}]: <PAST> {}".format(ind, len_links, archived_link))
         return 1, 0

--- a/wbsv/main.py
+++ b/wbsv/main.py
@@ -98,7 +98,8 @@ def wbsv(urls: Iterable[str], own: bool, only_target: bool, level: int, retry: i
     past, now, fail = 0, 0, 0
     print("[+]Target: {}".format(urls))
     c = Crawler.from_args(urls=urls, own=own, only_target=only_target, level=level)
-    retrieved_links: Set[Any] = set().union(*c.run_crawl())
+    retrieved_links_empty_set : Set[str] = set() #required for mypy type checking
+    retrieved_links: Set[str] = retrieved_links_empty_set.union(*c.run_crawl())
     len_links: int = len(retrieved_links)
     print("[+]{} URI(s) found.".format(len_links))
     a = Archiver(retry)

--- a/wbsv/main.py
+++ b/wbsv/main.py
@@ -94,14 +94,14 @@ def parse_args(args_list: Optional[List[str]] = None):
         return parser.parse_args()
 
 
-def usual(args):
+def wbsv(urls, own, only_target, level, retry) -> None:
     past, now, fail = 0, 0, 0
-    print("[+]Target: {}".format(args.url))
-    c = Crawler(args)
+    print("[+]Target: {}".format(urls))
+    c = Crawler.from_args(urls=urls, own=own, only_target=only_target, level=level)
     retrieved_links = set().union(*c.run_crawl())
     len_links: int = len(retrieved_links)
     print("[+]{} URI(s) found.".format(len_links))
-    a = Archiver(args)
+    a = Archiver(retry)
     for ind, link in enumerate(retrieved_links, 1):
         print("[{:02d}/{}]: Wait...".format(ind, len_links), end="\r")
         archive = a.archive(link)
@@ -114,8 +114,12 @@ def usual(args):
             print("[{:02d}/{}]: <FAIL> {}".format(ind, len_links, link))
             fail += 1
 
-    print("[+]FIN!: {}".format(args.url))
+    print("[+]FIN!: {}".format(urls))
     print("[+]ALL: {}, NOW: {}, PAST: {}, FAIL: {}".format(len_links, now, past, fail))
+
+
+def wbsv_from_parser_args(args):
+    wbsv(args.url, args.own, args.only_target, args.level, args.retry)
 
 
 def cache_or_now(ind, len_links: int, archived_link: str, cached_flag: bool) -> Tuple[int, int]:
@@ -127,8 +131,8 @@ def cache_or_now(ind, len_links: int, archived_link: str, cached_flag: bool) -> 
         return 0, 1
 
 
-def repl(args):
-    finish_words = ["end", "exit", "exit()", "break", "bye", ":q", "finish"]
+def wbsv_repl(args):
+    finish_words = {"end", "exit", "exit()", "break", "bye", ":q", "finish"}
     print("[[Input a target url (ex: https://google.com)]]")
     while True:
         link = input(">>> ").rstrip()
@@ -140,7 +144,7 @@ def repl(args):
         else:
             args.url = [link]
             try:
-                usual(args)
+                wbsv_from_parser_args(args)
             except Exception as e:
                 print(e, file=sys.stderr)
 
@@ -150,9 +154,9 @@ def _main():
         raise HttpConnectionNotFountError
     args = parse_args()
     if len(sys.argv) <= 1:
-        repl(args)
+        wbsv_repl(args)
     else:
-        usual(args)
+        wbsv_from_parser_args(args)
 
 
 def main():

--- a/wbsv/main.py
+++ b/wbsv/main.py
@@ -82,7 +82,7 @@ def parse_args(args_list: Optional[List[str]] = None) -> argparse.Namespace:
     parser.add_argument(
         "-O",
         "--own",
-        action='store_true',
+        action="store_true",
         help="Only URLs with the same domain as target",
     )
     parser.add_argument(
@@ -94,7 +94,9 @@ def parse_args(args_list: Optional[List[str]] = None) -> argparse.Namespace:
         return parser.parse_args()
 
 
-def wbsv(urls: Iterable[str], own: bool, only_target: bool, level: int, retry: int) -> None:
+def wbsv(
+    urls: Iterable[str], own: bool, only_target: bool, level: int, retry: int
+) -> None:
     past, now, fail = 0, 0, 0
     print("[+]Target: {}".format(urls))
     c = Crawler.from_args(urls=urls, own=own, only_target=only_target, level=level)
@@ -123,7 +125,9 @@ def wbsv_from_parser_args(args: argparse.Namespace) -> None:
     wbsv(args.url, args.own, args.only_target, args.level, args.retry)
 
 
-def cache_or_now(ind: int, len_links: int, archived_link: str, cached_flag: bool) -> Tuple[int, int]:
+def cache_or_now(
+    ind: int, len_links: int, archived_link: str, cached_flag: bool
+) -> Tuple[int, int]:
     if cached_flag:
         print("[{:02d}/{}]: <PAST> {}".format(ind, len_links, archived_link))
         return 1, 0
@@ -133,7 +137,7 @@ def cache_or_now(ind: int, len_links: int, archived_link: str, cached_flag: bool
 
 
 def wbsv_repl(args: argparse.Namespace) -> None:
-    finish_words = {"end", "exit", "exit()", "break", "bye", ":q", "finish"}
+    finish_words = ("end", "exit", "exit()", "break", "bye", ":q", "finish")
     print("[[Input a target url (ex: https://google.com)]]")
     while True:
         link = input(">>> ").rstrip()

--- a/wbsv/url_filters.py
+++ b/wbsv/url_filters.py
@@ -7,7 +7,7 @@ from urllib.parse import ParseResult, urlparse
 class UrlFilter(ABC):
 
     @abstractmethod
-    def test_url(self, parsed_url) -> bool:
+    def test_url(self, parsed_url: ParseResult) -> bool:
         pass
 
 
@@ -15,7 +15,7 @@ class UrlFilter(ABC):
 class SchemaFilter(UrlFilter):
     valid_schemas: Set[str] = dataclasses.field(default_factory=lambda: {"http", "https", "ftp", "file"})
 
-    def test_url(self, parsed_url) -> bool:
+    def test_url(self, parsed_url: ParseResult) -> bool:
         return parsed_url.scheme in self.valid_schemas
 
 
@@ -24,10 +24,10 @@ class OwnDomainFilter(UrlFilter):
     own_domains: Set[str]
 
     @staticmethod
-    def from_string_urls(urls: Iterable[str]):
+    def from_string_urls(urls: Iterable[str]) -> 'OwnDomainFilter':
         return OwnDomainFilter({urlparse(url).netloc for url in urls})
 
-    def test_url(self, parsed_url) -> bool:
+    def test_url(self, parsed_url: ParseResult) -> bool:
         return parsed_url.netloc in self.own_domains
 
 
@@ -35,5 +35,5 @@ class OwnDomainFilter(UrlFilter):
 class CombinedFilter(UrlFilter):
     filters: Iterable[UrlFilter]
 
-    def test_url(self, parsed_url) -> bool:
+    def test_url(self, parsed_url: ParseResult) -> bool:
         return all(f.test_url(parsed_url) for f in self.filters)

--- a/wbsv/url_filters.py
+++ b/wbsv/url_filters.py
@@ -5,7 +5,6 @@ from urllib.parse import ParseResult, urlparse
 
 
 class UrlFilter(ABC):
-
     @abstractmethod
     def test_url(self, parsed_url: ParseResult) -> bool:
         pass
@@ -13,7 +12,9 @@ class UrlFilter(ABC):
 
 @dataclasses.dataclass
 class SchemaFilter(UrlFilter):
-    valid_schemas: Set[str] = dataclasses.field(default_factory=lambda: {"http", "https", "ftp", "file"})
+    valid_schemas: Set[str] = dataclasses.field(
+        default_factory=lambda: {"http", "https", "ftp", "file"}
+    )
 
     def test_url(self, parsed_url: ParseResult) -> bool:
         return parsed_url.scheme in self.valid_schemas
@@ -24,7 +25,7 @@ class OwnDomainFilter(UrlFilter):
     own_domains: Set[str]
 
     @staticmethod
-    def from_string_urls(urls: Iterable[str]) -> 'OwnDomainFilter':
+    def from_string_urls(urls: Iterable[str]) -> "OwnDomainFilter":
         return OwnDomainFilter({urlparse(url).netloc for url in urls})
 
     def test_url(self, parsed_url: ParseResult) -> bool:

--- a/wbsv/url_filters.py
+++ b/wbsv/url_filters.py
@@ -1,0 +1,39 @@
+import dataclasses
+from abc import ABC, abstractmethod
+from typing import Set, Iterable
+from urllib.parse import ParseResult, urlparse
+
+
+class UrlFilter(ABC):
+
+    @abstractmethod
+    def test_url(self, parsed_url) -> bool:
+        pass
+
+
+@dataclasses.dataclass
+class SchemaFilter(UrlFilter):
+    valid_schemas: Set[str] = dataclasses.field(default_factory=lambda: {"http", "https", "ftp", "file"})
+
+    def test_url(self, parsed_url) -> bool:
+        return parsed_url.scheme in self.valid_schemas
+
+
+@dataclasses.dataclass
+class OwnDomainFilter(UrlFilter):
+    own_domains: Set[str]
+
+    @staticmethod
+    def from_string_urls(urls: Iterable[str]):
+        return OwnDomainFilter({urlparse(url).netloc for url in urls})
+
+    def test_url(self, parsed_url) -> bool:
+        return parsed_url.netloc in self.own_domains
+
+
+@dataclasses.dataclass
+class CombinedFilter(UrlFilter):
+    filters: Iterable[UrlFilter]
+
+    def test_url(self, parsed_url) -> bool:
+        return all(f.test_url(parsed_url) for f in self.filters)


### PR DESCRIPTION
At the moment the only way to use wbsv-cli from Python code is to start a new process, for example like this:
`subprocess.run(f"wbsv --retry {retries} --level {levels} {link_to_save}")`
This PR exposes the `usual` method (renamed to `wbsv`) so that it can be called directly from Python code.
Apart from that some readability improvements have been made, most method received type annotations and URL filtering has been moved to a separate class and covered with unit tests.
Required Python version has been set to 3.7 (3.5 and 3.6 are past end of life anyway but 3.7 can use dataclasses without importing backports)